### PR TITLE
fix(gdeq031t10): skip the panel refresh when the frame is unchanged

### DIFF
--- a/Drivers/gdeq031t10-module/source/gdeq031t10.cpp
+++ b/Drivers/gdeq031t10-module/source/gdeq031t10.cpp
@@ -387,9 +387,6 @@ static error_t gdeq031t10_draw_bitmap(Device* device, int32_t x_start, int32_t y
 
     xSemaphoreTake(internal->panel_mutex, portMAX_DELAY);
 
-    // Work-around until partial updates are working
-    internal->force_full_refresh = true;
-
     if (!internal->display_on) {
         // Display is off (deep sleep). Drop the frame without touching the shadow: the
         // mismatch it leaves behind makes the frame redraw after the next power-on.
@@ -418,6 +415,11 @@ static error_t gdeq031t10_draw_bitmap(Device* device, int32_t x_start, int32_t y
         xSemaphoreGive(internal->panel_mutex);
         return ERROR_NONE; // panel already shows this frame; don't refresh needlessly
     }
+
+    // Work-around until partial updates are working. It has to stay below the unchanged-frame
+    // check: a repaint that renders identical pixels must cost nothing, or a periodically
+    // repainting app pins the panel in a ~1.2s full-refresh loop.
+    internal->force_full_refresh = true;
 
     if (internal->force_full_refresh) {
         LOG_I(TAG, "draw_bitmap: refresh_full");


### PR DESCRIPTION
Fixes #623.

An app repainting the same content on a timer pinned the panel in a continuous full-refresh loop: 74 full refreshes in 90 s with the GPS Settings screen open, against 5 for an entire idle boot. Each costs this panel about 1.1 s of busy-wait while holding the LVGL lock, which is where the `statusbar: Mutex acquisition timeout` warnings come from. On e-ink it also means constant visible flashing and panel wear.

`lv_label_set_text()` has no equality check, so repainting an identical string still invalidates the display, and `MONOCHROME` forces `LV_DISPLAY_RENDER_MODE_FULL`, so it arrives here as a full-frame draw.

`draw_bitmap()` already diffs the frame against the shadow framebuffer and has a `nothing_changed` early-out, but the partial-update work-around set `force_full_refresh` at the top of the function, before the diff ran. That made the early-out unreachable.

This moves that assignment below the unchanged-frame check. The escape hatch that `reset()` and `start()` set is preserved, so a forced repaint after either still happens even when the pixels match. Any real change still takes the full-refresh path, so the partial-update work-around is unaffected.

**Measured on T-Deck Max**, same screen, same 90 s window:

| | Before | After |
| --- | --- | --- |
| Full-frame draws | ~74 | 57 |
| Panel refreshes | 74 | 10 |
| Skipped as unchanged | 0 | 47 |

**Tested:** LilyGO T-Deck Max. Simulator builds clean and `ctest` is green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented unnecessary full-screen refreshes when the displayed frame has not changed.
  * Improved refresh handling so unchanged repaints can complete without triggering redundant updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->