### PR TITLE
feat(gdeq031t10): support an optional frontlight

### DIFF
--- a/Drivers/gdeq031t10-module/bindings/gooddisplay,gdeq031t10.yaml
+++ b/Drivers/gdeq031t10-module/bindings/gooddisplay,gdeq031t10.yaml
@@ -36,3 +36,10 @@ properties:
     type: boolean
     default: false
     description: Panel is mounted upside down relative to the reference orientation
+  backlight:
+    type: phandle
+    default: "NULL"
+    description: >
+      Optional reference to this panel's frontlight device. E-paper panels are reflective, so
+      this lights the panel from the front rather than behind it, but it is driven through the
+      same BACKLIGHT_TYPE API and appears as the brightness control in Display settings.

--- a/Drivers/gdeq031t10-module/include/drivers/gdeq031t10.h
+++ b/Drivers/gdeq031t10-module/include/drivers/gdeq031t10.h
@@ -10,6 +10,8 @@ extern "C" {
 
 #include <tactility/drivers/gpio.h>
 
+struct Device;
+
 /** Waveform/refresh mode used for automatic full-screen refreshes. */
 enum Gdeq031t10RefreshMode {
     GDEQ031T10_REFRESH_FULL = 0, // ~3s, best quality
@@ -26,6 +28,8 @@ struct Gdeq031t10Config {
     enum Gdeq031t10RefreshMode refresh_mode;
     /** Panel is mounted upside down relative to the reference orientation */
     bool mirror_180;
+    /** Optional reference to this panel's frontlight/backlight device, NULL if none. */
+    struct Device* backlight;
 };
 
 #ifdef __cplusplus

--- a/Drivers/gdeq031t10-module/source/gdeq031t10.cpp
+++ b/Drivers/gdeq031t10-module/source/gdeq031t10.cpp
@@ -25,6 +25,9 @@
 constexpr auto* TAG = "GDEQ031T10";
 #define GET_CONFIG(device) (static_cast<const Gdeq031t10Config*>((device)->config))
 
+/** Capabilities every instance has; see gdeq031t10_has_capability() for the per-board ones. */
+#define GDEQ031T10_STATIC_CAPABILITIES (DISPLAY_CAPABILITY_ON_OFF | DISPLAY_CAPABILITY_SLOW_REFRESH)
+
 static constexpr int WIDTH = 240;
 static constexpr int HEIGHT = 320;
 static constexpr size_t FRAMEBUFFER_SIZE = (WIDTH * HEIGHT) / 8; // 1 bpp packed
@@ -532,8 +535,27 @@ static uint8_t gdeq031t10_get_frame_buffer_count(Device*) {
 
 // endregion
 
+static error_t gdeq031t10_get_backlight(Device* device, Device** backlight) {
+    auto* configured_backlight = GET_CONFIG(device)->backlight;
+    if (configured_backlight == nullptr) {
+        return ERROR_NOT_SUPPORTED;
+    }
+    *backlight = configured_backlight;
+    return ERROR_NONE;
+}
+
+// Whether this panel has a frontlight is per-board (the T-Deck Max has one, the T-Deck Pro
+// doesn't), so BACKLIGHT can't live in the driver-wide static capability mask.
+static bool gdeq031t10_has_capability(Device* device, uint32_t capability) {
+    uint32_t capabilities = GDEQ031T10_STATIC_CAPABILITIES;
+    if (GET_CONFIG(device)->backlight != nullptr) {
+        capabilities |= DISPLAY_CAPABILITY_BACKLIGHT;
+    }
+    return (capabilities & capability) == capability;
+}
+
 static const DisplayApi gdeq031t10_display_api = {
-    .capabilities = DISPLAY_CAPABILITY_ON_OFF | DISPLAY_CAPABILITY_SLOW_REFRESH,
+    .capabilities = GDEQ031T10_STATIC_CAPABILITIES,
     .reset = gdeq031t10_reset,
     .init = gdeq031t10_init,
     .draw_bitmap = gdeq031t10_draw_bitmap,
@@ -553,8 +575,8 @@ static const DisplayApi gdeq031t10_display_api = {
     .get_resolution_y = gdeq031t10_get_resolution_y,
     .get_frame_buffer = gdeq031t10_get_frame_buffer,
     .get_frame_buffer_count = gdeq031t10_get_frame_buffer_count,
-    .get_backlight = nullptr,
-    .has_capability = nullptr,
+    .get_backlight = gdeq031t10_get_backlight,
+    .has_capability = gdeq031t10_has_capability,
 };
 
 // region Driver lifecycle


### PR DESCRIPTION
Closes #625.

The driver hardcoded its capability mask and left `get_backlight` and `has_capability` as `nullptr`, so a board that wires a frontlight to the panel had no way to expose it.

Whether the panel has one is a per-board fact rather than a driver-wide one: the T-Deck Max has a frontlight, the T-Deck Pro does not. So `DISPLAY_CAPABILITY_BACKLIGHT` cannot live in the static mask and is reported dynamically from `has_capability()` instead, which is the approach you confirmed in #625.

`get_backlight()` returns `ERROR_NOT_SUPPORTED` when no `backlight` phandle is set, so boards without one report exactly what they did before this change.

The board wiring that uses it is #629, kept separate so this driver change is not blocked by a board review. Your `backlight_set_brightness_default()` proposal from #625 is not in here either, since it touches every board and deserves its own change.

**Tested:** LilyGO T-Deck Max. The brightness slider appears in Display settings and lights the panel.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional frontlight/backlight support for the GoodDisplay GDEQ031T10 e-paper panel.
  * Displays can now expose configured backlight controls through the standard brightness API.
  * Backlight capability is reported only when a compatible lighting device is configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->