### PR TITLE
feat(lilygo-tdeck-max): wire up the MIA-M10Q GPS

### DIFF
--- a/Devices/lilygo-tdeck-max/devicetree.yaml
+++ b/Devices/lilygo-tdeck-max/devicetree.yaml
@@ -7,4 +7,5 @@ dependencies:
   - Drivers/tca8418-module
   - Drivers/sy6970-module
   - Drivers/bq27220-module
+  - Drivers/gps-generic-module
 dts: lilygo,tdeck-max.dts

--- a/Devices/lilygo-tdeck-max/lilygo,tdeck-max.dts
+++ b/Devices/lilygo-tdeck-max/lilygo,tdeck-max.dts
@@ -8,8 +8,10 @@
 #include <tactility/bindings/esp32_spi.h>
 #include <tactility/bindings/esp32_sdspi.h>
 #include <tactility/bindings/esp32_pwm_ledc.h>
+#include <tactility/bindings/esp32_uart.h>
 #include <tactility/bindings/esp32_usbdevice.h>
 #include <tactility/bindings/pwm_backlight.h>
+#include <tactility/bindings/gpio_hog.h>
 #include <bindings/sx1262.h>
 #include <bindings/xl9555.h>
 #include <bindings/cst66xx.h>
@@ -17,6 +19,7 @@
 #include <bindings/tca8418.h>
 #include <bindings/sy6970.h>
 #include <bindings/bq27220.h>
+#include <gps_generic/bindings.h>
 
 // Reference: https://github.com/Xinyuan-LilyGO/T-Deck-MAX
 // lib/TDeckMaxBoard/src/TDeckMaxBoard.h, docs/pinmap.md
@@ -47,6 +50,15 @@
 		xl9555 {
 			compatible = "xlsemi,xl9555";
 			reg = <0x20>;
+
+			// GPS_EN (P02) powers the MIA-M10Q. Nested under the expander so it is driven the
+			// moment it starts. The receiver is started on demand from Settings -> GPS, but
+			// its rail has to be live before that UART is opened.
+			gps_power {
+				compatible = "gpio-hog";
+				pin = <&xl9555 2 GPIO_FLAG_NONE>;
+				mode = <GPIO_HOG_MODE_OUTPUT_HIGH>;
+			};
 		};
 
 		// Vendor docs label this chip "CST328", but the vendor HynTouch driver probes
@@ -187,4 +199,23 @@
 			compatible = "espressif,esp32-usbdevice-msc";
 		};
 	};
+
+	// Pin names are from the ESP32's point of view; the vendor schematic labels them from the
+	// module's (its GPS_TX/GPIO2 is our RX, its GPS_RX/GPIO16 is our TX).
+	uart_gps {
+		compatible = "espressif,esp32-uart";
+		port = <UART_NUM_2>;
+		pin-tx = <&gpio0 16 GPIO_FLAG_NONE>;
+		pin-rx = <&gpio0 2 GPIO_FLAG_NONE>;
+
+		// u-blox MIA-M10Q. 38400 is the M10 factory default; a module left at 9600 by other
+		// firmware won't probe, and has to be re-added at 9600 through Settings -> GPS.
+		gps {
+			compatible = "tactility,gps-generic";
+			status = "disabled";
+			baud-rate = <38400>;
+			model = <GPS_MODEL_UBLOX10>;
+		};
+	};
+
 };

--- a/Devices/lilygo-tdeck-max/lilygo,tdeck-max.dts
+++ b/Devices/lilygo-tdeck-max/lilygo,tdeck-max.dts
@@ -51,9 +51,6 @@
 			compatible = "xlsemi,xl9555";
 			reg = <0x20>;
 
-			// GPS_EN (P02) powers the MIA-M10Q. Nested under the expander so it is driven the
-			// moment it starts. The receiver is started on demand from Settings -> GPS, but
-			// its rail has to be live before that UART is opened.
 			gps_power {
 				compatible = "gpio-hog";
 				pin = <&xl9555 2 GPIO_FLAG_NONE>;
@@ -200,16 +197,12 @@
 		};
 	};
 
-	// Pin names are from the ESP32's point of view; the vendor schematic labels them from the
-	// module's (its GPS_TX/GPIO2 is our RX, its GPS_RX/GPIO16 is our TX).
 	uart_gps {
 		compatible = "espressif,esp32-uart";
 		port = <UART_NUM_2>;
 		pin-tx = <&gpio0 16 GPIO_FLAG_NONE>;
 		pin-rx = <&gpio0 2 GPIO_FLAG_NONE>;
 
-		// u-blox MIA-M10Q. 38400 is the M10 factory default; a module left at 9600 by other
-		// firmware won't probe, and has to be re-added at 9600 through Settings -> GPS.
 		gps {
 			compatible = "tactility,gps-generic";
 			status = "disabled";


### PR DESCRIPTION
Closes #627.

Devicetree only, no driver changes. The u-blox MIA-M10Q sits on `UART_NUM_2` (TX 16 / RX 2) and is powered from `XL9555` P02.

The rail is a `gpio-hog` nested under the expander node so it is driven the moment the expander starts, following `waveshare-s3-touch-lcd-43`. The receiver itself stays `status = "disabled"` and is started on demand from Settings -> GPS, matching the other boards that ship a GPS.

38400 is the M10 factory default. A module left at 9600 by other firmware will not probe, and has to be re-added at 9600 through Settings -> GPS.

**Tested:** LilyGO T-Deck Max. Enabling the receiver from Settings -> GPS produces `ublox: GNSS module configuration saved!`, which is a real UBX ACK from the module, so the rail, the pins and the baud rate are all confirmed. I have not yet had it outdoors long enough for a position fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added GPS receiver support for the LilyGO T-Deck Max.
  * Configured automatic GPS power control through the device’s I/O expander.
  * Added UART communication for the u-blox MIA-M10Q GPS module at 38400 baud.
  * Prepared the device for reliable GPS positioning and location data when a compatible receiver is connected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->